### PR TITLE
Add migration files for other tabes

### DIFF
--- a/src/db/migrations/20211021144138_createTournaments.js
+++ b/src/db/migrations/20211021144138_createTournaments.js
@@ -1,0 +1,12 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("tournaments", (table) => {
+    table.increments("tournament_id").primary();
+    table.string("map_name");
+    table.dateTime("date");
+    table.string("start_time");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("tournaments");
+};

--- a/src/db/migrations/20211021145012_createTeams.js
+++ b/src/db/migrations/20211021145012_createTeams.js
@@ -1,0 +1,10 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("teams", (table) => {
+    table.increments("team_id").primary();
+    table.string("team_name");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable("teams");
+};

--- a/src/db/migrations/20211021145218_createPlayerStats.js
+++ b/src/db/migrations/20211021145218_createPlayerStats.js
@@ -1,0 +1,15 @@
+exports.up = function (knex) {
+  return knex.schema.createTable("player_stats", (table) => {
+    table.increments(stat_id).primary();
+    table.integer("team_id").unsigned().notNullable();
+    table.foreign("team_id").references("team_id").inTable("teams");
+    table.integer("tournament_id").unsigned().notNullable();
+    table.foreign("tournament_id").references("team_id").inTable("tournaments");
+    table.integer("player_id").unsigned().notNullable();
+    table.foreign("player_id").references("player_id").inTable("players");
+  });
+};
+
+exports.down = function (knex) {
+    return knex.schema.dropTable("player_stats")
+};


### PR DESCRIPTION
Add migration files for other tables. 

I worked off the schema Dante drew up and the data Parker made, so there were some slight changes. 

Tournaments has `map_name` instead of `is_Rebirth` to match more closely with the data examples (guessing also to prevent table re-works incased COD gets more warzone maps). 


